### PR TITLE
Update Go module name

### DIFF
--- a/examples/tnd/main.go
+++ b/examples/tnd/main.go
@@ -4,8 +4,8 @@ import (
 	"flag"
 	"strings"
 
-	"github.com/T-Systems-MMS/tnd/pkg/trustnet"
 	log "github.com/sirupsen/logrus"
+	"github.com/telekom-mms/tnd/pkg/trustnet"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/T-Systems-MMS/tnd
+module github.com/telekom-mms/tnd
 
 go 1.18
 

--- a/pkg/trustnet/tnd.go
+++ b/pkg/trustnet/tnd.go
@@ -3,8 +3,8 @@ package trustnet
 import (
 	"net"
 
-	"github.com/T-Systems-MMS/tnd/internal/trusthttps"
 	log "github.com/sirupsen/logrus"
+	"github.com/telekom-mms/tnd/internal/trusthttps"
 )
 
 // TND realizes the trusted network detection


### PR DESCRIPTION
The repository was moved into a new GitHub organization. Update the Go module name accordingly.