### PR TITLE
Add exported probing method to TND

### DIFF
--- a/pkg/trustnet/tnd.go
+++ b/pkg/trustnet/tnd.go
@@ -185,6 +185,14 @@ func (t *TND) Stop() {
 	}
 }
 
+// Probe triggers a trusted network probe
+func (t *TND) Probe() {
+	select {
+	case t.probes <- struct{}{}:
+	case <-t.done:
+	}
+}
+
 // Results returns the results channel
 func (t *TND) Results() chan bool {
 	return t.results

--- a/pkg/trustnet/tnd_test.go
+++ b/pkg/trustnet/tnd_test.go
@@ -49,6 +49,19 @@ func TestTNDStartStop(t *testing.T) {
 	tnd.Stop()
 }
 
+// TestTNDProbe tests Probe of TND
+func TestTNDProbe(t *testing.T) {
+	tnd := NewTND()
+	tnd.Start()
+	tnd.Probe()
+	want := false
+	got := <-tnd.Results()
+	if got != want {
+		t.Errorf("got %t, want %t", got, want)
+	}
+	tnd.Stop()
+}
+
 // TestTNDResults tests Results of TND
 func TestTNDResults(t *testing.T) {
 	tnd := NewTND()


### PR DESCRIPTION
Add an exported method that allows users to trigger probing the trusted network status.