### PR TITLE
Add setter and getter methods to TND

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ func main() {
 	t := tnd.NewDetector(tnd.NewConfig())
 
 	// set trusted https server(s)
+	servers := make(map[string]string)
 	url := "https://trusted1.mynetwork.com:443"
 	hash := "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
-	t.AddServer(url, hash)
+	servers[url] = hash
+	t.SetServers(servers)
 
 	// start tnd
 	t.Start()

--- a/examples/tnd/main.go
+++ b/examples/tnd/main.go
@@ -47,9 +47,7 @@ func main() {
 	t := tnd.NewDetector(tnd.NewConfig())
 
 	// set trusted https servers
-	for url, hash := range httpsServers {
-		t.AddServer(url, hash)
-	}
+	t.SetServers(httpsServers)
 
 	// start tnd
 	t.Start()

--- a/pkg/tnd/detector.go
+++ b/pkg/tnd/detector.go
@@ -32,17 +32,36 @@ type Detector struct {
 	runAgain bool
 }
 
-// AddServer adds the https server url and its expected hash to the list of
-// trusted servers; note: all servers must be added before Start().
-func (d *Detector) AddServer(url, hash string) {
-	server := https.NewServer(url, hash)
-	d.servers = append(d.servers, server)
+// SetServers sets the https server urls and their expected hashes in the
+// servers map as trusted servers; map key is the server url, value is the
+// server's hash. Note: servers must be set before Start().
+func (d *Detector) SetServers(servers map[string]string) {
+	d.servers = []*https.Server{}
+	for url, hash := range servers {
+		server := https.NewServer(url, hash)
+		d.servers = append(d.servers, server)
+	}
+}
+
+// GetServers returns the https servers as map; map key is the server url,
+// value is the server's hash.
+func (d *Detector) GetServers() map[string]string {
+	servers := make(map[string]string)
+	for _, s := range d.servers {
+		servers[s.URL] = s.Hash
+	}
+	return servers
 }
 
 // SetDialer sets a custom dialer for the https connections; note: the dialer
 // must be set before Start().
 func (d *Detector) SetDialer(dialer *net.Dialer) {
 	d.dialer = dialer
+}
+
+// GetDialer returns the custom dialer for the https connections.
+func (d *Detector) GetDialer() *net.Dialer {
+	return d.dialer
 }
 
 // sendResult sends result over channel c.

--- a/pkg/tnd/detector_test.go
+++ b/pkg/tnd/detector_test.go
@@ -4,39 +4,36 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"net"
+	"reflect"
 	"testing"
 )
 
-// TestTNDAddServer tests AddServer of TND.
-func TestTNDAddServer(t *testing.T) {
+// TestDetectorSetGetServers tests SetServers and GetServers of Detector.
+func TestDetectorSetGetServers(t *testing.T) {
 	tnd := NewDetector(NewConfig())
+
 	url := "http://test.example.com:442"
 	cert := []byte("raw test certificate")
 	hash := sha256.Sum256(cert)
 	hs := hex.EncodeToString(hash[:])
-	tnd.AddServer(url, hs)
+	want := map[string]string{url: hs}
 
-	want := url
-	got := tnd.servers[0].URL
-	if got != want {
-		t.Errorf("got %s, want %s", got, want)
-	}
+	tnd.SetServers(want)
+	got := tnd.GetServers()
 
-	want = hs
-	got = tnd.servers[0].Hash
-	if got != want {
-		t.Errorf("got %s, want %s", got, want)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
 	}
 }
 
-// TestTNDSetDialer tests SetDialer of TND.
-func TestTNDSetDialer(t *testing.T) {
+// TestDetectorSetGetDialer tests SetDialer and GetDialer of Detector.
+func TestDetectorSetGetDialer(t *testing.T) {
 	tnd := NewDetector(NewConfig())
 	dialer := &net.Dialer{}
 	tnd.SetDialer(dialer)
 
 	want := dialer
-	got := tnd.dialer
+	got := tnd.GetDialer()
 	if got != want {
 		t.Errorf("got %p, want %p", got, want)
 	}

--- a/pkg/tnd/tnd.go
+++ b/pkg/tnd/tnd.go
@@ -7,8 +7,10 @@ import (
 
 // TND is the trusted network detection.
 type TND interface {
-	AddServer(url, hash string)
+	SetServers(map[string]string)
+	GetServers() map[string]string
 	SetDialer(dialer *net.Dialer)
+	GetDialer() *net.Dialer
 	Start()
 	Stop()
 	Probe()

--- a/pkg/tnd/tndtest/detector.go
+++ b/pkg/tnd/tndtest/detector.go
@@ -7,12 +7,14 @@ import (
 
 // Funcs are functions used by Detector for use in tests.
 type Funcs struct {
-	AddServer func(url, hash string)
-	SetDialer func(dialer *net.Dialer)
-	Start     func()
-	Stop      func()
-	Probe     func()
-	Results   func() chan bool
+	SetServers func(servers map[string]string)
+	GetServers func() map[string]string
+	SetDialer  func(dialer *net.Dialer)
+	GetDialer  func() *net.Dialer
+	Start      func()
+	Stop       func()
+	Probe      func()
+	Results    func() chan bool
 }
 
 // Detector is a simple Detector for use in tests.
@@ -20,12 +22,20 @@ type Detector struct {
 	Funcs Funcs
 }
 
-// AddServer adds the https server url and its expected hash to the list of
-// trusted servers.
-func (d *Detector) AddServer(url, hash string) {
-	if d.Funcs.AddServer != nil {
-		d.Funcs.AddServer(url, hash)
+// SetServers sets the https server urls and expected hashes as the list of
+// trusted servers. Map key is the server url, value is the hash.
+func (d *Detector) SetServers(servers map[string]string) {
+	if d.Funcs.SetServers != nil {
+		d.Funcs.SetServers(servers)
 	}
+}
+
+// GetServers returns the trusted server urls and hashes.
+func (d *Detector) GetServers() map[string]string {
+	if d.Funcs.GetServers != nil {
+		return d.Funcs.GetServers()
+	}
+	return nil
 }
 
 // SetDialer sets a custom dialer for the https connections.
@@ -33,6 +43,14 @@ func (d *Detector) SetDialer(dialer *net.Dialer) {
 	if d.Funcs.SetDialer != nil {
 		d.Funcs.SetDialer(dialer)
 	}
+}
+
+// GetDialer returns the custom dialer for the https connections.
+func (d *Detector) GetDialer() *net.Dialer {
+	if d.Funcs.GetDialer != nil {
+		return d.Funcs.GetDialer()
+	}
+	return nil
 }
 
 // Start starts the trusted network detection.

--- a/pkg/tnd/tndtest/detector_test.go
+++ b/pkg/tnd/tndtest/detector_test.go
@@ -2,45 +2,60 @@ package tndtest
 
 import (
 	"net"
+	"reflect"
 	"testing"
 )
 
-// TestDetectorAddServer tests AddServer of Detector.
-func TestDetectorAddServer(t *testing.T) {
+// TestDetectorSetGetServers tests SetServers and GetServers of Detector.
+func TestDetectorSetGetServers(t *testing.T) {
 	d := NewDetector()
 
 	// test no func set
 	url := "https://example.com"
 	hash := "abcdefabcdefabcdefabcdef"
-	d.AddServer(url, hash)
+	servers := map[string]string{url: hash}
+	d.SetServers(servers)
+	if d.GetServers() != nil {
+		t.Errorf("servers should be nil")
+	}
 
 	// test func set
-	gotURL := ""
-	gotHash := ""
-	d.Funcs.AddServer = func(url, hash string) {
-		gotURL = url
-		gotHash = hash
+	testServers := map[string]string{}
+	d.Funcs.SetServers = func(s map[string]string) {
+		testServers = s
 	}
-	d.AddServer(url, hash)
-	if gotURL != url || gotHash != hash {
-		t.Errorf("got %s %s, want %s %s", gotURL, gotHash, url, hash)
+	d.Funcs.GetServers = func() map[string]string {
+		return testServers
+	}
+	d.SetServers(servers)
+	got := d.GetServers()
+	if !reflect.DeepEqual(got, servers) {
+		t.Errorf("got %v, want %v", got, servers)
 	}
 }
 
-// TestDetectorSetDialer tests SetDialer of Detector.
-func TestDetectorSetDialer(t *testing.T) {
+// TestDetectorSetDialer tests SetDialer and GetDialer of Detector.
+func TestDetectorSetGetDialer(t *testing.T) {
 	d := NewDetector()
 
 	// test no func set
 	d.SetDialer(&net.Dialer{})
+	if d.GetDialer() != nil {
+		t.Errorf("dialer should be nil")
+	}
 
 	// test func set
 	want := &net.Dialer{}
-	got := &net.Dialer{}
+	testDialer := &net.Dialer{}
 	d.Funcs.SetDialer = func(dialer *net.Dialer) {
-		got = dialer
+		testDialer = dialer
 	}
+	d.Funcs.GetDialer = func() *net.Dialer {
+		return testDialer
+	}
+
 	d.SetDialer(want)
+	got := d.GetDialer()
 	if got != want {
 		t.Errorf("got %p, want %p", got, want)
 	}


### PR DESCRIPTION
Add setter and getter methods to the TND interface:

- Remove AddServer()
- Add SetServers()
- Add GetServers()
- Add GetDialer()