### PR TITLE
Feature/make tnd start fallible

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ func main() {
 	t.SetServers(servers)
 
 	// start tnd
-	t.Start()
+	if err := t.Start(); err != nil {
+		log.Fatal(err)
+	}
 	for r := range t.Results() {
 		log.Println("Trusted Network:", r)
 	}

--- a/examples/tnd/main.go
+++ b/examples/tnd/main.go
@@ -51,7 +51,9 @@ func main() {
 	t.SetServers(httpsServers)
 
 	// start tnd
-	t.Start()
+	if err := t.Start(); err != nil {
+		log.Fatal(err)
+	}
 	for r := range t.Results() {
 		log.WithField("trusted", r).Info("TND result")
 	}

--- a/examples/tnd/main.go
+++ b/examples/tnd/main.go
@@ -1,3 +1,4 @@
+// package main contains a TND example.
 package main
 
 import (

--- a/internal/files/watch_test.go
+++ b/internal/files/watch_test.go
@@ -1,13 +1,79 @@
 package files
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+)
 
 // TestWatchStartStop tests Start() and Stop() of Watch.
-func TestWatchStartStop(_ *testing.T) {
+func TestWatchStartStop(t *testing.T) {
 	probes := make(chan struct{})
-	fw := NewWatch(probes)
-	fw.Start()
-	fw.Stop()
+
+	// error creating fsnotify.Watcher
+	t.Run("watcher error", func(t *testing.T) {
+		// fail when creating watcher
+		defer func() { fsnotifyNewWatcher = fsnotify.NewWatcher }()
+		fsnotifyNewWatcher = func() (*fsnotify.Watcher, error) {
+			return nil, errors.New("test error")
+		}
+
+		// test error
+		fw := NewWatch(probes)
+		if err := fw.Start(); err == nil {
+			t.Errorf("start should fail")
+		}
+	})
+
+	// error adding dir to watcher
+	t.Run("add dir error", func(t *testing.T) {
+		// cleanups after test
+		oldAdd := watcherAdd
+		defer func() { watcherAdd = oldAdd }()
+
+		// test dirs
+		for _, dir := range []string{
+			etc,
+			systemdResolveDir,
+		} {
+			// fail when adding dir
+			watcherAdd = func(_ *fsnotify.Watcher, name string) error {
+				if name == dir {
+					return errors.New("test error")
+				}
+				return nil
+			}
+
+			// test error
+			fw := NewWatch(probes)
+			if err := fw.Start(); err == nil {
+				t.Errorf("start should fail")
+			}
+		}
+	})
+
+	// no errors
+	t.Run("no errors", func(t *testing.T) {
+		// cleanups after test
+		oldEtc := etc
+		oldResolve := systemdResolveDir
+		defer func() {
+			etc = oldEtc
+			systemdResolveDir = oldResolve
+		}()
+
+		// create test dirs
+		etc = t.TempDir()
+		systemdResolveDir = t.TempDir()
+
+		// test without errors
+		fw := NewWatch(probes)
+		if err := fw.Start(); err != nil {
+			t.Errorf("start should not fail: %v", err)
+		}
+		fw.Stop()
+	})
 }
 
 // TestNewWatch tests NewWatch.

--- a/internal/routes/watch_test.go
+++ b/internal/routes/watch_test.go
@@ -1,13 +1,35 @@
 package routes
 
-import "testing"
+import (
+	"errors"
+	"testing"
+
+	"github.com/vishvananda/netlink"
+)
 
 // TestWatchStartStop tests Start and Stop of Watch.
-func TestWatchStartStop(_ *testing.T) {
+func TestWatchStartStop(t *testing.T) {
 	probes := make(chan struct{})
-	rw := NewWatch(probes)
-	rw.Start()
-	rw.Stop()
+
+	t.Run("subscribe error", func(t *testing.T) {
+		defer func() { netlinkRouteSubscribe = netlink.RouteSubscribe }()
+		netlinkRouteSubscribe = func(chan<- netlink.RouteUpdate, <-chan struct{}) error {
+			return errors.New("test error")
+		}
+
+		rw := NewWatch(probes)
+		if err := rw.Start(); err == nil {
+			t.Error("start should fail")
+		}
+	})
+
+	t.Run("no errors", func(t *testing.T) {
+		rw := NewWatch(probes)
+		if err := rw.Start(); err != nil {
+			t.Errorf("start should not fail: %v", err)
+		}
+		rw.Stop()
+	})
 }
 
 // TestWatchProbes tests Probes of Watch.
@@ -23,6 +45,9 @@ func TestWatchProbes(t *testing.T) {
 func TestNewWatch(t *testing.T) {
 	probes := make(chan struct{})
 	rw := NewWatch(probes)
+	if rw.events == nil {
+		t.Errorf("got nil, want != nil")
+	}
 	if rw.probes != probes {
 		t.Errorf("got %p, want %p", rw.probes, probes)
 	}

--- a/pkg/tnd/tnd.go
+++ b/pkg/tnd/tnd.go
@@ -11,7 +11,7 @@ type TND interface {
 	GetServers() map[string]string
 	SetDialer(dialer *net.Dialer)
 	GetDialer() *net.Dialer
-	Start()
+	Start() error
 	Stop()
 	Probe()
 	Results() chan bool

--- a/pkg/tnd/tndtest/detector.go
+++ b/pkg/tnd/tndtest/detector.go
@@ -11,7 +11,7 @@ type Funcs struct {
 	GetServers func() map[string]string
 	SetDialer  func(dialer *net.Dialer)
 	GetDialer  func() *net.Dialer
-	Start      func()
+	Start      func() error
 	Stop       func()
 	Probe      func()
 	Results    func() chan bool
@@ -54,10 +54,11 @@ func (d *Detector) GetDialer() *net.Dialer {
 }
 
 // Start starts the trusted network detection.
-func (d *Detector) Start() {
+func (d *Detector) Start() error {
 	if d.Funcs.Start != nil {
-		d.Funcs.Start()
+		return d.Funcs.Start()
 	}
+	return nil
 }
 
 // Stop stops the running TND.

--- a/pkg/tnd/tndtest/detector_test.go
+++ b/pkg/tnd/tndtest/detector_test.go
@@ -71,8 +71,9 @@ func TestDetectorStart(t *testing.T) {
 	// test func set
 	want := true
 	got := false
-	d.Funcs.Start = func() {
+	d.Funcs.Start = func() error {
 		got = true
+		return nil
 	}
 	d.Start()
 	if got != want {


### PR DESCRIPTION
Make TND start fallible and remove log.Fatal():

- TND: return error in Start()
- Routes Watch: return error in Start() and remove log.Fatal()
- Files Watch: return error in Start() and remove log.Fatal()