### PR TITLE
Update coverage summary GitHub action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Process results
         if: always()
-        uses: malaupa/go-test-coverage-summary-action@v2.0.0
+        uses: malaupa/go-test-coverage-summary-action@v3.0.0
         with:
           test_results: "test.out"
           coverage_profile: "cover.out"


### PR DESCRIPTION
Update the GitHub action malaupa/go-test-coverage-summary-action used for the Go test coverage summary to version 3.